### PR TITLE
feat: switch trigger from push to pull request event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create fake GITHUB_EVENT_PATH
         run: |
           sha=$(git rev-parse HEAD)
-          printf '{"before":"%s","after":"%s"}' "$sha" "$sha" > event.json
+          printf '{"pull_request":{"base":{"sha":"%s"},"head":{"sha":"%s"}}, "repository":{"full_name":"dummy/dummy"}}' "$sha" "$sha" > event.json
       - name: Run execution test via docker image
         run: |
           mkdir -p artifacts/gha-nbconvert
@@ -39,6 +39,7 @@ jobs:
             -e INPUT_OUTPUT_DIR=artifacts/gha-nbconvert \
             -e GITHUB_WORKSPACE=/github/workspace \
             -e GITHUB_EVENT_PATH=/github/workspace/event.json \
-            -e GITHUB_REF=refs/heads/main \
+            -e GITHUB_EVENT_NAME=pull_request \
+            -e GITHUB_HEAD_REF=main \
             -v "$PWD":/github/workspace \
             gha-nbconvert:test

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "gha-nbconvert"
 author: "fractal255"
 description: |
-  On every push, detect changed *.ipynb files, convert them to *.py under artifacts/gha-nbconvert.
+  On every pull request, detect changed *.ipynb files, convert them to *.py under artifacts/gha-nbconvert.
 branding:
   icon: book-open
   color: blue

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -71,3 +71,22 @@ def test_shas_from_pull_request() -> None:
     before, after = exctr._shas_from_event(evt, event_name="pull_request")
     assert before == "a"*40
     assert after == "b"*40
+
+
+def test_is_fork_pr_missing_repo() -> None:
+    ev = {
+        "pull_request": {"head": {"sha": "b"*40}, "base": {"sha": "a"*40}},
+        "repository": {"full_name": "dummy/dummy"},
+    }
+    assert exctr._is_fork_pr(ev) is False
+
+
+def test_is_fork_pr_true() -> None:
+    ev = {
+        "pull_request": {
+            "head": {"repo": {"full_name": "someone/fork"}, "sha": "b"*40},
+            "base": {"sha": "a"*40},
+        },
+        "repository": {"full_name": "dummy/dummy"},
+    }
+    assert exctr._is_fork_pr(ev) is True

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -59,3 +59,15 @@ def test_diff_first_push(fake_repo: Path) -> None:
     )
     # This is the initial push, so there should be no differences.
     assert paths == []
+
+
+def test_shas_from_pull_request() -> None:
+    evt = {
+        "pull_request": {
+            "base": {"sha": "a"*40},
+            "head": {"sha": "b"*40},
+        }
+    }
+    before, after = exctr._shas_from_event(evt, event_name="pull_request")
+    assert before == "a"*40
+    assert after == "b"*40


### PR DESCRIPTION
# Purpose

Migrates the **`gha-nbconvert`** workflow (and its composite action) from a **`push`-trigger** to a **`pull_request`-trigger** so that notebook-to-Python conversion happens *only* when a PR is opened or updated.
This aligns the automation with our review flow and eliminates redundant runs on every local branch push.

# Key Changes

| Area                                | Summary                                                                                                                                                  |
| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Workflow · `gha-nbconvert.yml`**  | `push` ➜ `pull_request` (`opened`, `synchronize`, `reopened`) & checkout `github.head_ref`.                                                              |
| **Composite Action · `action.yml`** | Docs: wording changed from “push” to “pull request”.                                                                                                     |
| **Core Logic · `executor.py`**      | *New* helper `_shas_from_event()`<br>• Safely extracts `base.sha` / `head.sha` from PR payloads.<br>• Early-returns on forked PRs or unsupported events. |
| **Tests**                           | Added unit cases for PR payloads and fork detection.                                                                                                     |
| **CI Test Workflow**                | Synthetic `event.json` updated to PR schema.                                                                                                             |


# How It Works

1. On each PR update GitHub fires the workflow.
2. `executor.py` diffs **`base_sha … head_sha`** and converts only changed `.ipynb` files.
3. For PRs from forks, the job exits early (no write permission).


# Validation

* `pytest`: green (push & PR scenarios).
* Matrix run on a throw-away PR confirmed:

  * ✅ Action executes on PR commit.
  * ✅ No run on subsequent background pushes.
  * ✅ Forked-PR path returns early without error.
