### PR TITLE
fix: fix action.yml to publish the action to GitHub Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "gha-nbconvert"
 author: "fractal255"
 description: |
-  On every pull request, detect changed Jupyter Notebooks (*.ipynb) files and convert them to *.py files under your specified directory.
+  On every pull request, detect changed Jupyter Notebooks (*.ipynb) and convert them to *.py files under your output dir.
 branding:
   icon: chevrons-right
   color: blue


### PR DESCRIPTION
## Key Changes

- Fixed action.yml to publish the action to GitHub Marketplace, because the description must be less than 125 characters.
- No code changes
